### PR TITLE
Fix HTTP Method in JWT login request to be a POST

### DIFF
--- a/src/api/auth/oidc/requests.rs
+++ b/src/api/auth/oidc/requests.rs
@@ -214,7 +214,7 @@ pub struct OIDCCallbackRequest {
 /// * Response: N/A
 /// * Reference: https://www.vaultproject.io/api/auth/jwt#jwt-login
 #[derive(Builder, Debug, Default, Endpoint)]
-#[endpoint(path = "/auth/{self.mount}/login", builder = "true")]
+#[endpoint(path = "/auth/{self.mount}/login", method = "POST", builder = "true")]
 #[builder(setter(into, strip_option), default)]
 pub struct JWTLoginRequest {
     #[endpoint(skip)]


### PR DESCRIPTION
When trying out JWT login into Vault I got errors on the vault server saying GET was not supported.  Looking at the API docs and the source comments shows it should be a POST.

Changed the method to be POST and the code runs successfully now.